### PR TITLE
Fixes for kernel 4.15, etc

### DIFF
--- a/ap/ap_connect.c
+++ b/ap/ap_connect.c
@@ -256,9 +256,9 @@ VOID APMakeBssBeacon(struct rtmp_adapter *pAd, INT apidx)
 	for (i = 0; i < TXWISize; i += 4) {
 		u32 dword;
 
-		dword =  *ptr +
-			(*(ptr + 1) << 8);
-			(*(ptr + 2) << 16);
+		dword =  *ptr |
+			(*(ptr + 1) << 8) |
+			(*(ptr + 2) << 16) |
 			(*(ptr + 3) << 24);
 
 		mt76u_reg_write(pAd, reg_base + i, dword);
@@ -275,9 +275,9 @@ VOID APMakeBssBeacon(struct rtmp_adapter *pAd, INT apidx)
 	for ( i= 0; i< FrameLen; i+=4) {
 		u32 dword;
 
-		dword =  *ptr +
-			(*(ptr + 1) << 8);
-			(*(ptr + 2) << 16);
+		dword =  *ptr |
+			(*(ptr + 1) << 8) |
+			(*(ptr + 2) << 16) |
 			(*(ptr + 3) << 24);
 
 		mt76u_reg_write(pAd, reg_base + i, dword);

--- a/common/cmm_asic.c
+++ b/common/cmm_asic.c
@@ -1211,9 +1211,9 @@ VOID AsicEnableIbssSync(struct rtmp_adapter *pAd)
 	for (i = 0; i < TXWISize; i += 4) {
 		u32 dword;
 
-		dword =  *ptr +
-			(*(ptr + 1) << 8);
-			(*(ptr + 2) << 16);
+		dword =  *ptr |
+			(*(ptr + 1) << 8) |
+			(*(ptr + 2) << 16) |
 			(*(ptr + 3) << 24);
 
 		mt76u_reg_write(pAd, HW_BEACON_BASE0(pAd) + i, dword);
@@ -1225,9 +1225,9 @@ VOID AsicEnableIbssSync(struct rtmp_adapter *pAd)
 	for (i = 0; i< beaconLen; i += 4) {
 		u32 dword;
 
-		dword =  *ptr +
-			(*(ptr + 1) << 8);
-			(*(ptr + 2) << 16);
+		dword =  *ptr |
+			(*(ptr + 1) << 8) |
+			(*(ptr + 2) << 16) |
 			(*(ptr + 3) << 24);
 
 		mt76u_reg_write(pAd, HW_BEACON_BASE0(pAd) + TXWISize + i,

--- a/common/cmm_mac_usb.c
+++ b/common/cmm_mac_usb.c
@@ -785,8 +785,8 @@ VOID RT28xx_UpdateBeaconToAsic(struct rtmp_adapter *pAd,
 				u32 dword;
 
 				dword =  *ptr +
-					(*(ptr + 1) << 8);
-					(*(ptr + 2) << 16);
+					(*(ptr + 1) << 8) +
+					(*(ptr + 2) << 16) +
 					(*(ptr + 3) << 24);
 
 				mt76u_reg_write(pAd,
@@ -810,8 +810,8 @@ VOID RT28xx_UpdateBeaconToAsic(struct rtmp_adapter *pAd,
 				memmove(ptr, pBeaconFrame, 4);
 
 				dword =  *ptr +
-					(*(ptr + 1) << 8);
-					(*(ptr + 2) << 16);
+					(*(ptr + 1) << 8) +
+					(*(ptr + 2) << 16) +
 					(*(ptr + 3) << 24);
 
 				mt76u_reg_write(pAd,

--- a/include/os/rt_linux.h
+++ b/include/os/rt_linux.h
@@ -374,7 +374,11 @@ typedef struct tasklet_struct  *POS_NET_TASK_STRUCT;
 typedef struct timer_list	OS_NDIS_MINIPORT_TIMER;
 typedef struct timer_list	OS_TIMER;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0))
+typedef void (*TIMER_FUNCTION)(struct timer_list *);
+#else
 typedef void (*TIMER_FUNCTION)(unsigned long);
+#endif
 
 #define RTMP_TIME_AFTER(a,b)		\
 	(typecheck(unsigned long, (unsigned long)a) && \

--- a/os/linux/cfg80211/cfg80211.c
+++ b/os/linux/cfg80211/cfg80211.c
@@ -2041,12 +2041,6 @@ static int CFG80211_OpsBitrateSet(
 	return 0;
 }
 
-#ifdef CONFIG_NL80211_TESTMODE
-static int CFG80211_OpsTestModeCmd(IN struct wiphy *pWiphy, void *Data, int len)
-{
-}
-#endif /* CONFIG_NL80211_TESTMODE */
-
 static int CFG80211_start_p2p_device(
 	struct wiphy *pWiphy,
 	struct wireless_dev *wdev)
@@ -2250,9 +2244,6 @@ struct cfg80211_ops CFG80211_Ops = {
 	.add_station            = CFG80211_OpsStaAdd,
 	.change_station         = CFG80211_OpsStaChg,
 //	.set_bitrate_mask                       = CFG80211_OpsBitrateSet,
-#ifdef CONFIG_NL80211_TESTMODE
-        .testmode_cmd           = CFG80211_OpsTestModeCmd,
-#endif /* CONFIG_NL80211_TESTMODE */
 };
 
 /* =========================== Global Function ============================== */

--- a/os/linux/cfg80211/cfg80211.c
+++ b/os/linux/cfg80211/cfg80211.c
@@ -172,14 +172,14 @@ static const uint32_t CipherSuites[] = {
 /* get RALINK pAd control block in 80211 Ops */
 struct rtmp_adapter *MAC80211_PAD_GET(struct wiphy *pWiphy)
 {
-	struct rtmp_adapter *pAd = wiphy_priv(pWiphy);
+	struct rtmp_adapter **pAd = wiphy_priv(pWiphy);
 
 	if (pAd == NULL)
-		DBGPRINT(RT_DEBUG_ERROR,								\
-			("80211> %s but pAd = NULL!", __FUNCTION__));	\
+		DBGPRINT(RT_DEBUG_ERROR,
+			("80211> %s but pAd = NULL!", __FUNCTION__));
 
-	return pAd;
-}							\
+	return *pAd;
+}
 
 /*
 ========================================================================

--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -110,9 +110,13 @@ static inline VOID __RTMP_OS_Init_Timer(
 	IN PVOID data)
 {
 	if (!timer_pending(pTimer)) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0))
+		timer_setup(pTimer, function, 0);
+#else
 		init_timer(pTimer);
 		pTimer->data = (unsigned long)data;
 		pTimer->function = function;
+#endif
 	}
 }
 

--- a/os/linux/usb_main_dev.c
+++ b/os/linux/usb_main_dev.c
@@ -327,6 +327,8 @@ static int rtusb_probe(struct usb_interface *intf, const USB_DEVICE_ID *id)
 	rv = rt2870_probe(intf, dev, id, &pAd);
 	if (rv != 0)
 		usb_put_dev(dev);
+	else
+		usb_set_intfdata(intf, pAd);
 	return rv;
 }
 


### PR DESCRIPTION
This series fixes:
timer_setup() for >= 4.15,
segfault when 'iw dev wlan0 scan' command issued,
segfault in rtusb_disconnect(),
wrong value calculations in a few places.

It does successfully found my AP, but I've not managed it to connect, not in 5Ghz, nor in 2.4Ghz.
I'm using it on ARM64 platform.
